### PR TITLE
SoftwareSerial dependency removed. Upgraded to support C++11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ SoftwareSerial shieldSerial(7, 8);  //RX and TX
 
 void setup() {
   Serial.begin(9600);               // Initialize serial communication
-  SIM900 sim900(&shieldSerial);     // Initialize the SIM900 shield
+  shieldSerial.begin(9600) // Initialize shield communication
+  SIM900 sim900(shieldSerial);     // Initialize the SIM900 shield
 
   // Your code goes here...
 }

--- a/examples/apn_example/apn_example.ino
+++ b/examples/apn_example/apn_example.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
 
   SIM900APN access;
   access.apn = F("");

--- a/examples/board_info/board_info.ino
+++ b/examples/board_info/board_info.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
 
   Serial.println(F("Dumping board informations..."));
   Serial.println(F("-----------------------------------------"));

--- a/examples/card_info/card_info.ino
+++ b/examples/card_info/card_info.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   uint8_t phonebookIndex = 1;
 
   SIM900CardAccount accountInfo;

--- a/examples/dial_up/dial_up.ino
+++ b/examples/dial_up/dial_up.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
 
   sim900.dialUp("+XXxxxxxxxxxx");
   delay(20000);

--- a/examples/handshake/handshake.ino
+++ b/examples/handshake/handshake.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
 
   Serial.println(
     sim900.handshake() ? "Handshaked!" : "Something went wrong."

--- a/examples/network_op/network_op.ino
+++ b/examples/network_op/network_op.ino
@@ -6,7 +6,8 @@ SoftwareSerial shieldSerial(7, 8);
 void setup() {
   Serial.begin(9600);
 
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   SIM900Operator network = sim900.networkOperator();
 
   Serial.println(F("SIM900 Current Network Operator"));

--- a/examples/phonebook_capacity/phonebook_capacity.ino
+++ b/examples/phonebook_capacity/phonebook_capacity.ino
@@ -6,7 +6,8 @@ SoftwareSerial shieldSerial(7, 8);
 void setup() {
   Serial.begin(9600);
 
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   SIM900PhonebookCapacity capacity = sim900.phonebookCapacity();
 
   Serial.println(F("Phonebook Capacity"));

--- a/examples/phonebook_example/phonebook_example.ino
+++ b/examples/phonebook_example/phonebook_example.ino
@@ -5,7 +5,8 @@ SoftwareSerial shieldSerial(7, 8);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   uint8_t index = 1;
 
   SIM900CardAccount account;

--- a/examples/rtc_example/rtc_example.ino
+++ b/examples/rtc_example/rtc_example.ino
@@ -7,7 +7,8 @@ void printRTC(SIM900RTC rtc);
 
 void setup() {
   Serial.begin(9600);
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
 
   SIM900RTC rtc;
   rtc.year = 2;

--- a/examples/signal_strength/signal_strength.ino
+++ b/examples/signal_strength/signal_strength.ino
@@ -6,7 +6,8 @@ SoftwareSerial shieldSerial(7, 8);
 void setup() {
   Serial.begin(9600);
 
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   SIM900Signal signal = sim900.signal();
 
   Serial.println(F("Signal Strength"));

--- a/examples/sms_send_example/sms_send_example.ino
+++ b/examples/sms_send_example/sms_send_example.ino
@@ -6,7 +6,8 @@ SoftwareSerial shieldSerial(7, 8);
 void setup() {
   Serial.begin(9600);
 
-  SIM900 sim900(&shieldSerial);
+  shieldSerial.begin(9600);
+  SIM900 sim900(shieldSerial);
   Serial.println(
     sim900.sendSMS("+XXxxxxxxxxxx", "Hello, world!!")
       ? "Sent!" : "Not sent."

--- a/src/sim900.cpp
+++ b/src/sim900.cpp
@@ -22,17 +22,16 @@
  */
 
 #include "sim900.h"
-#include <SoftwareSerial.h>
 
 void SIM900::sendCommand(String message) {
-    this->sim900->println(message);
+    this->sim900.println(message);
 }
 
 String SIM900::getResponse() {
     delay(500);
     
-    if(this->sim900->available() > 0) {
-        String response = this->sim900->readString();
+    if(this->sim900.available() > 0) {
+        String response = this->sim900.readString();
         response.trim();
 
         return response;
@@ -82,10 +81,7 @@ String SIM900::queryResult() {
     return result;
 }
 
-SIM900::SIM900(SoftwareSerial *_sim900):
-    sim900(_sim900) {
-    this->sim900->begin(9600);
-}
+SIM900::SIM900(Stream& _sim900):sim900(_sim900){}
 
 bool SIM900::handshake() {
     this->sendCommand(F("AT"));
@@ -122,9 +118,9 @@ SIM900Signal SIM900::signal() {
     return signal;
 }
 
-void SIM900::close() {
-    this->sim900->end();
-}
+// void SIM900::close() {
+//     this->sim900->end();
+// }
 
 SIM900DialResult SIM900::dialUp(String number) {
     this->sendCommand("ATD+ " + number + ";");
@@ -194,7 +190,7 @@ bool SIM900::sendSMS(String number, String message) {
     delay(500);
     this->sendCommand(message);
     delay(500);
-    this->sim900->write(0x1a);
+    this->sim900.write(0x1a);
 
     return this->getReturnedMode().startsWith(">");
 }

--- a/src/sim900.cpp
+++ b/src/sim900.cpp
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-#include <sim900.h>
+#include "sim900.h"
 #include <SoftwareSerial.h>
 
 void SIM900::sendCommand(String message) {

--- a/src/sim900.cpp
+++ b/src/sim900.cpp
@@ -408,7 +408,7 @@ SIM900CardAccount SIM900::cardNumber() {
     account.number = response.substring(delim1 + 2, delim2 - 1);
     account.type = (uint8_t) response.substring(delim2 + 1, delim3).toInt();
     account.speed = (uint8_t) response.substring(delim3 + 1, delim4).toInt();
-    account.service = (uint8_t) response.substring(delim4 + 1).toInt();
+    account.service = intToSIM900CardService((uint8_t) response.substring(delim4 + 1).toInt());
     account.numberType = static_cast<SIM900PhonebookType>(0);
 
     return account;

--- a/src/sim900.cpp
+++ b/src/sim900.cpp
@@ -201,8 +201,8 @@ bool SIM900::sendSMS(String number, String message) {
 
 SIM900Operator SIM900::networkOperator() {
     SIM900Operator simOperator;
-    simOperator.mode = 0;
-    simOperator.format = 0;
+    simOperator.mode = static_cast<SIM900OperatorMode>(0);
+    simOperator.format = static_cast<SIM900OperatorFormat>(0);
     simOperator.name = "";
 
     this->sendCommand(F("AT+COPS?"));
@@ -211,8 +211,8 @@ SIM900Operator SIM900::networkOperator() {
     uint8_t delim1 = response.indexOf(','),
         delim2 = response.indexOf(',', delim1 + 1);
 
-    simOperator.mode = (uint8_t) response.substring(0, delim1).toInt();
-    simOperator.format = (uint8_t) response.substring(delim1 + 1, delim2).toInt();
+    simOperator.mode = intToSIM900OperatorMode((uint8_t) response.substring(0, delim1).toInt());
+    simOperator.format = intToSIM900OperatorFormat((uint8_t) response.substring(delim1 + 1, delim2).toInt());
     simOperator.name = response.substring(delim2 + 2, response.length() - 2);
 
     return simOperator;
@@ -347,7 +347,7 @@ SIM900CardAccount SIM900::retrievePhonebook(uint8_t index) {
     this->sendCommand("AT+CPBR=" + String(index));
 
     SIM900CardAccount accountInfo;
-    accountInfo.numberType = 0;
+    accountInfo.numberType = static_cast<SIM900PhonebookType>(0);
 
     String response = this->queryResult();
     response = response.substring(response.indexOf(',') + 1);
@@ -359,8 +359,8 @@ SIM900CardAccount SIM900::retrievePhonebook(uint8_t index) {
     
     uint8_t type = (uint8_t) response.substring(delim1 + 1, delim2).toInt();
     if(type == 129 || type == 145)
-        accountInfo.numberType = type;
-    else accountInfo.numberType = 0;
+        accountInfo.numberType = static_cast<SIM900PhonebookType>(type);
+    else accountInfo.numberType = static_cast<SIM900PhonebookType>(0);
 
     accountInfo.name = response.substring(delim2 + 2, response.length() - 2);
     return accountInfo;
@@ -409,7 +409,7 @@ SIM900CardAccount SIM900::cardNumber() {
     account.type = (uint8_t) response.substring(delim2 + 1, delim3).toInt();
     account.speed = (uint8_t) response.substring(delim3 + 1, delim4).toInt();
     account.service = (uint8_t) response.substring(delim4 + 1).toInt();
-    account.numberType = 0;
+    account.numberType = static_cast<SIM900PhonebookType>(0);
 
     return account;
 }

--- a/src/sim900.h
+++ b/src/sim900.h
@@ -27,7 +27,7 @@
 #include <Arduino.h>
 #include <SoftwareSerial.h>
 
-#include <sim900_defs.h>
+#include "sim900_defs.h"
 
 /**
  * 

--- a/src/sim900.h
+++ b/src/sim900.h
@@ -25,7 +25,6 @@
 #define SIM900_H
 
 #include <Arduino.h>
-#include <SoftwareSerial.h>
 
 #include "sim900_defs.h"
 
@@ -42,7 +41,7 @@
 class SIM900 {
 private:
     /// The SoftwareSerial object used for communication with the SIM900 module.
-    SoftwareSerial *sim900;
+    Stream& sim900;
 
     /// A flag indicating whether Access Point Name (APN) configuration is set.
     bool hasAPN = false;
@@ -73,7 +72,7 @@ public:
      * @param _sim900 A pointer to the SoftwareSerial object for communication with the SIM900 module.
      * 
      */
-    SIM900(SoftwareSerial *_sim900);
+    SIM900(Stream& _sim900);
 
     /**
      * 

--- a/src/sim900_defs.h
+++ b/src/sim900_defs.h
@@ -87,6 +87,13 @@ typedef enum _SIM900OperatorFormat {
     SIM900_OPERATOR_FORMAT_MANUAL_AUTO
 } SIM900OperatorFormat;
 
+SIM900OperatorFormat intToSIM900OperatorFormat(int i){
+    if (i < SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO || i > SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_MANUAL_AUTO)
+        return SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO;
+    else
+        return static_cast<SIM900OperatorFormat>(i);
+}
+
 /**
  * 
  * @enum SIM900OperatorMode
@@ -121,6 +128,13 @@ typedef enum _SIM900OperatorMode {
     /// E-UTRAN (4G) operating mode, for advanced 4G LTE network connectivity.
     SIM900_OPERATOR_MODE_E_UTRAN
 } SIM900OperatorMode;
+
+SIM900OperatorMode intToSIM900OperatorMode(int i){
+    if (i < SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM || i > SIM900OperatorMode::SIM900_OPERATOR_MODE_E_UTRAN)
+        return SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM;
+    else
+        return static_cast<SIM900OperatorMode>(i);
+}
 
 /**
  * 

--- a/src/sim900_defs.h
+++ b/src/sim900_defs.h
@@ -87,6 +87,18 @@ typedef enum _SIM900OperatorFormat {
     SIM900_OPERATOR_FORMAT_MANUAL_AUTO
 } SIM900OperatorFormat;
 
+/**
+ * @param i Integer input to be casted.
+ * @return A valid SIM900OperatorFormat value.
+ * 
+ * @brief This function receives an integer value and checks its range. If the value is not in range, the 
+ * default value of SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO is returned other than that a static_cast from
+ * the integer value to SIM900OperatorFormat is performed and the result is returned.
+ * 
+ * @details From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
+ * values. The same is true for newer Arduino compilers, too. So impilicit cast of integer value to an enum type is no longer allowed. For the sake of the safety of an explicit
+ * cast is better to first check the range of the input. 
+*/
 SIM900OperatorFormat intToSIM900OperatorFormat(int i){
     if (i < SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO || i > SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_MANUAL_AUTO)
         return SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO;
@@ -129,6 +141,18 @@ typedef enum _SIM900OperatorMode {
     SIM900_OPERATOR_MODE_E_UTRAN
 } SIM900OperatorMode;
 
+/**
+ * @param i Integer input to be casted.
+ * @return A valid SIM900OperatorMode value.
+ * 
+ * @brief This function receives an integer value and checks its range. If the value is not in range, the 
+ * default value of SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM is returned other than that a static_cast from
+ * the integer value to SIM900OperatorMode is performed and the result is returned.
+ * 
+ * @details From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
+ * values. The same is true for newer Arduino compilers, too. So impilicit cast of integer value to an enum type is no longer allowed. For the sake of the safety of an explicit
+ * cast is better to first check the range of the input. 
+*/
 SIM900OperatorMode intToSIM900OperatorMode(int i){
     if (i < SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM || i > SIM900OperatorMode::SIM900_OPERATOR_MODE_E_UTRAN)
         return SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM;

--- a/src/sim900_defs.h
+++ b/src/sim900_defs.h
@@ -91,11 +91,9 @@ typedef enum _SIM900OperatorFormat {
  * @param i Integer input to be casted.
  * @return A valid SIM900OperatorFormat value.
  * 
- * @brief This function receives an integer value and checks its range. If the value is not in range, the 
- * default value of SIM900OperatorFormat::SIM900_OPERATOR_FORMAT_AUTO is returned other than that a static_cast from
- * the integer value to SIM900OperatorFormat is performed and the result is returned.
+ * @brief A function to safely cast from integer value to SIM900OperatorFormat. Invalid inputs are casted to default value of SIM900_OPERATOR_FORMAT_AUTO.
  * 
- * @details From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
+ * From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
  * values. The same is true for newer Arduino compilers, too. So impilicit cast of integer value to an enum type is no longer allowed. For the sake of the safety of an explicit
  * cast is better to first check the range of the input. 
 */
@@ -145,11 +143,9 @@ typedef enum _SIM900OperatorMode {
  * @param i Integer input to be casted.
  * @return A valid SIM900OperatorMode value.
  * 
- * @brief This function receives an integer value and checks its range. If the value is not in range, the 
- * default value of SIM900OperatorMode::SIM900_OPERATOR_MODE_GSM is returned other than that a static_cast from
- * the integer value to SIM900OperatorMode is performed and the result is returned.
+ * @brief A function to safely cast from integer value to SIM900OperatorMode. Invalid inputs are casted to default value of SIM900_OPERATOR_MODE_GSM.
  * 
- * @details From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
+ * From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
  * values. The same is true for newer Arduino compilers, too. So impilicit cast of integer value to an enum type is no longer allowed. For the sake of the safety of an explicit
  * cast is better to first check the range of the input. 
 */
@@ -187,6 +183,23 @@ typedef enum _SIM900CardService {
     /// Fax service for facsimile communication.
     SIM900_CARD_SERVICE_FAX
 } SIM900CardService;
+
+/**
+ * @param i Integer input to be casted.
+ * @return A valid SIM900CardService value.
+ * 
+ * @brief A function to safely cast from integer value to SIM900CardService. Invalid inputs are casted to default value of SIM900_CARD_SERVICE_ASYNC.
+ * 
+ * From C++11 up to newer versions of C++, enumerators are considered as a specific type rather than integer 
+ * values. The same is true for newer Arduino compilers, too. So impilicit cast of integer value to an enum type is no longer allowed. For the sake of the safety of an explicit
+ * cast is better to first check the range of the input. 
+*/
+SIM900CardService intToSIM900CardService(int i){
+    if (i < SIM900CardService::SIM900_CARD_SERVICE_ASYNC || i > SIM900CardService::SIM900_CARD_SERVICE_FAX)
+        return SIM900CardService::SIM900_CARD_SERVICE_ASYNC;
+    else
+        return static_cast<SIM900CardService>(i);
+}
 
 /**
  * 


### PR DESCRIPTION
By using a Stream you can support both hardware and software serial while having the same functionality. By the way, the initialization of the serial interface should be handled by the user himself which is not a complicated task and offers more flexibility. Also, the Arduino library manager conflicts with adding the library due to this dependency, at least for me 🙂.

After brute-forcing the library to my Arduino IDE, I received some "type mismatch" errors regarding casting integer values to enum ones. It seems that You were using an older version of Arduino C++ compiler which allows such a thing but with more recent versions such a cast should be done explicitly through a static_cast function. I also handled this issue in my Fork.

I am planning to create a new branch, continue the development of the library, and test it on my setup which consists of an ESP32-based LILYGO T-Display and a SIM900A Mini V3.8.2. module. I will use software serial in my project. 
